### PR TITLE
Use helper plots for workload threshold analysis

### DIFF
--- a/ML4HL_OD_RAI_toolbox.ipynb
+++ b/ML4HL_OD_RAI_toolbox.ipynb
@@ -8,11 +8,11 @@
     "# 1. Introduction\n",
     "This notebook is part of a machine learning for healthcare exercise, focusing on using the Responsible AI (RAI) package to enhance clinical decision-making. The toolkit will be used to analyze opioid use disorder (OD) risk, with three key objectives:\n",
     "\n",
-    "1. Analyze Errors and Explore Interpretability of Models: We will run Interpret-Community\u2019s global explainers to generate feature importance insights and visualize model errors with the Error Analysis dashboard\n",
+    "1. Analyze Errors and Explore Interpretability of Models: We will run Interpret-Community’s global explainers to generate feature importance insights and visualize model errors with the Error Analysis dashboard\n",
     "\n",
     "2. Plan real-world action through counterfactual and causal analysis: By leveraging counterfactual examples and causal inference, we will explore decision-making strategies based on opioid prescription patterns and patient comorbidities to understand possible interventions and their impacts\n",
     "\n",
-    "3. Assess addiction risk predictions: A classification model trained on patient-level features (income, surgeries, opioid prescription days, and comorbidities A\u2013V) will be evaluated to examine its performance in predicting risk of opioid use disorder and to inform prevention strategies\n",
+    "3. Assess addiction risk predictions: A classification model trained on patient-level features (income, surgeries, opioid prescription days, and comorbidities A–V) will be evaluated to examine its performance in predicting risk of opioid use disorder and to inform prevention strategies\n",
     "\n",
     "**The goal is to provide non-trivial insights for clinical decision making, leveraging machine learning paired with responsible AI tools, to improve patient outcomes in the healthcare context.**\n",
     "\n",
@@ -76,9 +76,15 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "RAI core/widgets unavailable: No module named 'responsibleai'\nInterpret-Community unavailable: No module named 'interpret_community'\nError Analysis unavailable: No module named 'erroranalysis'\nFairlearn metrics unavailable: No module named 'fairlearn'\n_RAI=False, _INTERPRET=False, _ERRANALYSIS=False, _FAIRLEARN=False, _DICE=False, _ECONML=False\n"
+     "output_type": "stream",
+     "text": [
+      "RAI core/widgets unavailable: No module named 'responsibleai'\n",
+      "Interpret-Community unavailable: No module named 'interpret_community'\n",
+      "Error Analysis unavailable: No module named 'erroranalysis'\n",
+      "Fairlearn metrics unavailable: No module named 'fairlearn'\n",
+      "_RAI=False, _INTERPRET=False, _ERRANALYSIS=False, _FAIRLEARN=False, _DICE=False, _ECONML=False\n"
+     ]
     }
    ],
    "source": [
@@ -271,9 +277,9 @@
    "source": [
     "# 5. Training, Validation and Testing - 80/15/5 stratified split\n",
     "\n",
-    "Train\u2013test split\n",
+    "Train–test split\n",
     "\n",
-    "- Prevents \u201cpeeking\u201d at data and overestimating performance\n",
+    "- Prevents “peeking” at data and overestimating performance\n",
     "- Mimics real-world deployment where models face unseen patients\n",
     "- Always evaluate on data not used for training"
    ]
@@ -348,11 +354,11 @@
     "A naive majority-class baseline clarifies the minimum standard any model must beat, highlighting the danger of ignoring minority patients and ensuring improvements carry meaningful weight in healthcare decision making\n",
     "\n",
     "**ROC AUC**  \n",
-    "- 0.5 \u2192 no discrimination\n",
-    "- 0.6\u20130.7 \u2192 poor\n",
-    "- 0.7\u20130.8 \u2192 fair\n",
-    "- 0.8\u20130.9 \u2192 good\n",
-    "- \u2265 0.9 \u2192 excellent\n",
+    "- 0.5 → no discrimination\n",
+    "- 0.6–0.7 → poor\n",
+    "- 0.7–0.8 → fair\n",
+    "- 0.8–0.9 → good\n",
+    "- ≥ 0.9 → excellent\n",
     "\n",
     "**PR AUC**  \n",
     "- Must be interpreted against event prevalence `p` in the validation set  "
@@ -661,7 +667,7 @@
    "id": "b02c73af",
    "metadata": {},
    "source": [
-    "# 7. Deciding where to cut off i.e. what probability is \u201chigh risk enough\u201d to trigger an intervention?"
+    "# 7. Deciding where to cut off i.e. what probability is “high risk enough” to trigger an intervention?"
    ]
   },
   {
@@ -849,31 +855,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "THR = res[\"threshold\"] # <- use the threshold from the previous step\n",
+    "THR = res[\"threshold\"]  # <- use the threshold from the previous step\n",
     "y_score_val = positive_scores(calibrated_clf, X_val)\n",
-    "ids = np.arange(len(y_val))\n",
     "\n",
-    "# Sort patients by predicted risk\n",
-    "order = np.argsort(-y_score_val)\n",
-    "top_idx = order[:30]   # top 30 for visualization\n",
-    "top_scores = y_score_val[top_idx]\n",
-    "top_true = np.asarray(y_val)[top_idx].astype(int)\n",
-    "\n",
-    "# Split indices for TP vs FP\n",
-    "tp_idx = np.where(top_true == 1)[0]\n",
-    "fp_idx = np.where(top_true == 0)[0]\n",
-    "\n",
-    "plt.figure(figsize=(10, 4))\n",
-    "plt.bar(tp_idx, top_scores[tp_idx], color=\"tab:red\", label=\"True addicted (TP)\")\n",
-    "plt.bar(fp_idx, top_scores[fp_idx], color=\"tab:gray\", label=\"Not addicted (FP)\")\n",
-    "plt.axhline(THR, linestyle=\"--\", color=\"black\", label=f\"Threshold = {THR:.2f}\")\n",
-    "\n",
-    "plt.xlabel(\"Patients ranked by predicted risk\")\n",
-    "plt.ylabel(\"Predicted risk\")\n",
-    "plt.title(\"Top 30 highest-risk patients on validation\")\n",
-    "plt.legend()\n",
-    "plt.tight_layout()\n",
-    "plt.show()"
+    "# Patient-level prioritization view at the chosen threshold\n",
+    "plot_topk_at_threshold(y_val, y_score_val, chosen_threshold=THR, top_k=30)\n"
    ]
   },
   {
@@ -883,36 +869,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "y_score_val = positive_scores(calibrated_clf, X_val)\n",
-    "order = np.argsort(-y_score_val)\n",
-    "y_sorted = np.asarray(y_val)[order].astype(int)\n",
-    "\n",
-    "# Cumulative recall\n",
-    "cum_tp = np.cumsum(y_sorted)\n",
-    "total_pos = cum_tp[-1] if cum_tp.size else 0\n",
-    "alerts = np.arange(1, len(y_sorted) + 1)\n",
-    "recall_curve = cum_tp / total_pos if total_pos > 0 else np.zeros_like(cum_tp)\n",
-    "\n",
-    "# Budget for alerts\n",
-    "n_budget = int(np.ceil(ALERTS_BUDGET * len(y_val) / 1000.0))\n",
-    "\n",
-    "# Recall at budget\n",
-    "recall_at_budget = recall_curve[n_budget - 1] if n_budget > 0 and n_budget <= len(y_val) else 0.0\n",
-    "\n",
-    "# Plot\n",
-    "plt.figure()\n",
-    "plt.plot(alerts, recall_curve, label=\"Cumulative recall\")\n",
-    "plt.axvline(n_budget, linestyle=\"--\", color=\"red\", label=f\"Budget = {n_budget} alerts\")\n",
-    "\n",
-    "# Annotate recall at budget\n",
-    "plt.scatter(n_budget, recall_at_budget, color=\"black\", zorder=5)\n",
-    "plt.text(n_budget + 2, recall_at_budget, f\"Recall = {recall_at_budget:.2f}\", va=\"center\")\n",
-    "\n",
-    "plt.xlabel(\"Number of alerts\")\n",
-    "plt.ylabel(\"Recall\")\n",
-    "plt.title(\"Cumulative capture of true cases vs alerts\")\n",
-    "plt.legend()\n",
-    "plt.show()"
+    "# Cumulative recall vs alerts with vertical line at alerts implied by THR\n",
+    "plot_cumulative_recall_at_threshold(y_val, y_score_val, chosen_threshold=THR)\n"
    ]
   },
   {
@@ -922,26 +880,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Cumulative precision at top-k alerts\n",
-    "alerts = np.arange(1, len(y_sorted) + 1)\n",
-    "cum_tp = np.cumsum(y_sorted)\n",
-    "precision_curve = cum_tp / alerts\n",
-    "\n",
-    "# Alerts budget scaled to validation size\n",
-    "prec_at_budget = precision_curve[n_budget - 1] if 0 < n_budget <= len(y_sorted) else 0.0\n",
-    "\n",
-    "# Plot\n",
-    "plt.figure()\n",
-    "plt.plot(alerts, precision_curve, label=\"Precision at top-k alerts\")\n",
-    "plt.axvline(n_budget, linestyle=\"--\", label=f\"Budget = {n_budget} alerts\")\n",
-    "plt.scatter(n_budget, prec_at_budget, zorder=5)\n",
-    "plt.text(n_budget + max(2, len(y_sorted)//100), prec_at_budget, f\"Precision = {prec_at_budget:.2f}\", va=\"center\")\n",
-    "\n",
-    "plt.xlabel(\"Number of alerts\")\n",
-    "plt.ylabel(\"Precision\")\n",
-    "plt.title(\"Precision vs number of alerts\")\n",
-    "plt.legend()\n",
-    "plt.show()\n"
+    "# Precision/recall vs threshold annotated at THR\n",
+    "summary = summary_at_threshold(y_val, y_score_val, THR)\n",
+    "recall_at_thr = float(summary[\"recall\"].iloc[0]) if not summary.empty else 0.0\n",
+    "plot_recall_floor_curves(y_val, y_score_val, recall_floor=recall_at_thr, chosen_threshold=THR)\n"
    ]
   },
   {
@@ -959,7 +901,7 @@
     "2. In medicine, it's often the case that missing a true case (false negative) is often much worse than raising extra alarms (false positives)\n",
     "3. A recall floor enforces a safety guarantee: the model must capture at least e.g. 60% of patients who will become addicted\n",
     "\n",
-    "Among thresholds that satisfy recall \u2265 0.6, you then pick the one with the best precision, to minimize unnecessary undertreatment and workload"
+    "Among thresholds that satisfy recall ≥ 0.6, you then pick the one with the best precision, to minimize unnecessary undertreatment and workload"
    ]
   },
   {
@@ -1486,7 +1428,7 @@
     "treatment_features = [\"Surgery\", \"rx_ds\"]\n",
     "rai_insights.causal.add(treatment_features=treatment_features)\n",
     "\n",
-    "print(\"Explainer, Error Analysis, Counterfactual, and Causal components added \u2705\")"
+    "print(\"Explainer, Error Analysis, Counterfactual, and Causal components added ✅\")"
    ]
   },
   {


### PR DESCRIPTION
## Summary
- replace the manual numpy/matplotlib plotting in the workload threshold section with the reusable helper functions
- reuse `summary_at_threshold` to annotate the precision/recall plot at the selected threshold

## Testing
- `python - <<'PY'
import nbformat
from pathlib import Path
from IPython.display import display, Markdown

nb = nbformat.read(Path('ML4HL_OD_RAI_toolbox.ipynb'), as_version=4)
ns = {'display': display, 'Markdown': Markdown}
for idx, cell in enumerate(nb.cells):
    if cell.cell_type != 'code':
        continue
    exec(cell.source, ns)
    if idx >= 35:
        break
PY`


------
https://chatgpt.com/codex/tasks/task_b_68dd41d42c748333b6fbd7a22d826410